### PR TITLE
[Fix]  date filter should filter records for the whole days

### DIFF
--- a/Filter/AbstractDateFilter.php
+++ b/Filter/AbstractDateFilter.php
@@ -87,6 +87,15 @@ abstract class AbstractDateFilter extends Filter
                 return;
             }
 
+            // date filter should filter records for the whole days
+            if ($this->time === false) {
+                if ($data['value'] instanceof \DateTime && $data['type'] == DateType::TYPE_GREATER_EQUAL) {
+                    $data['value']->setTime(0, 0, 0);
+                }
+                if ($data['value'] instanceof \DateTime && $data['type'] == DateType::TYPE_LESS_EQUAL) {
+                    $data['value']->setTime(23, 59, 59);
+                }
+            }
             // default type for simple filter
             $data['type'] = !isset($data['type']) || !is_numeric($data['type']) ? DateType::TYPE_EQUAL : $data['type'];
 


### PR DESCRIPTION
On datagrid filter when we choose date and LESS_EQUAL operator and submit, it did not retreive the data with current date because the date time is 00:00:00. So we will set the time to 23:59:59